### PR TITLE
Fix stop button reset

### DIFF
--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -310,6 +310,8 @@ print("Hello,", name)
     if (i8 && workerRef.current) {
       i8[0] = 2; // SIGINT
       append("^C\n");
+      setIsRunning(false); // Reset running state immediately
+      setExecutionEndTime(Date.now());
       setTimeout(() => {
         if (workerRef.current) {
           append("[force stop]\n");


### PR DESCRIPTION
## Summary
- reset running state and execution end time as soon as Stop is clicked

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ceb4f7158832194394643aa213e39